### PR TITLE
詳細パンを新しいタブで開けるようにする

### DIFF
--- a/src/components/containers/BreadGroup/Cache.svelte
+++ b/src/components/containers/BreadGroup/Cache.svelte
@@ -3,7 +3,6 @@
   import { SIZE } from '../../../../const/pager'
   import BreadType from '../../../const/bread-type'
   import { getBreads } from '../../../utils/idb'
-  import { moveBreadDetail } from '../../../utils/router'
   import Group from '../../parts/Bread/Group'
 
   let isReading = false
@@ -52,5 +51,4 @@
   description="パン詳細画面を開くと、IndexedDB
   を通してブラウザに保存されます。共有端末をご利用の方で、閲覧済みキャッシュを見られて困る方は、プライベートウィンドウでご利用ください。"
   {isReading}
-  on:click={moveBreadDetail}
   on:readMore={onReadMore} />

--- a/src/components/containers/BreadGroup/Favorites.svelte
+++ b/src/components/containers/BreadGroup/Favorites.svelte
@@ -6,7 +6,6 @@
     existsAfter,
     items,
   } from '../../../states/breads-summary/favorites'
-  import { moveBreadDetail } from '../../../utils/router'
   import Group from '../../parts/Bread/Group'
 
   let isReading = false
@@ -26,5 +25,4 @@
   showReadMore={$existsAfter}
   description=""
   {isReading}
-  on:click={moveBreadDetail}
   on:readMore={onReadMore} />

--- a/src/components/containers/BreadGroup/New.svelte
+++ b/src/components/containers/BreadGroup/New.svelte
@@ -6,7 +6,6 @@
     existsAfter,
     items,
   } from '../../../states/breads-summary/latest'
-  import { moveBreadDetail } from '../../../utils/router'
   import Group from '../../parts/Bread/Group'
 
   let isReading = false
@@ -26,5 +25,4 @@
   showReadMore={$existsAfter}
   description=""
   {isReading}
-  on:click={moveBreadDetail}
   on:readMore={onReadMore} />

--- a/src/components/containers/BreadGroup/SelfMade.svelte
+++ b/src/components/containers/BreadGroup/SelfMade.svelte
@@ -6,7 +6,6 @@
     existsAfter,
     items,
   } from '../../../states/breads-summary/self-made'
-  import { moveBreadDetail } from '../../../utils/router'
   import Group from '../../parts/Bread/Group'
 
   let isReading = false
@@ -26,5 +25,4 @@
   showReadMore={$existsAfter}
   description=""
   {isReading}
-  on:click={moveBreadDetail}
   on:readMore={onReadMore} />

--- a/src/components/parts/Bread/Group.stories.js
+++ b/src/components/parts/Bread/Group.stories.js
@@ -27,7 +27,6 @@ export const パン10個_最新 = () => ({
     isReading: boolean('isReading', false),
   },
   on: {
-    click: e => console.info(e.detail),
     readMore: e => console.info(e.detail),
   },
 })
@@ -42,7 +41,6 @@ export const パン3個_お気に入り_読込中 = () => ({
     isReading: boolean('isReading', true),
   },
   on: {
-    click: e => console.info(e.detail),
     readMore: e => console.info(e.detail),
   },
 })
@@ -57,7 +55,6 @@ export const パン0個_自作 = () => ({
     isReading: boolean('isReading', false),
   },
   on: {
-    click: e => console.info(e.detail),
     readMore: e => console.info(e.detail),
   },
 })
@@ -72,7 +69,6 @@ export const パン5個_キャッシュ = () => ({
     isReading: boolean('isReading', false),
   },
   on: {
-    click: e => console.info(e.detail),
     readMore: e => console.info(e.detail),
   },
 })

--- a/src/components/parts/Bread/Group.svelte
+++ b/src/components/parts/Bread/Group.svelte
@@ -53,8 +53,7 @@
           title={item.title}
           nanoId={item.nanoId}
           userId={item.userId}
-          {type}
-          on:click />
+          {type} />
       {/each}
 
       {#if showReadMore}

--- a/src/components/parts/Bread/Summary.stories.js
+++ b/src/components/parts/Bread/Summary.stories.js
@@ -16,9 +16,6 @@ export const 新規_６文字 = () => ({
     userId: text('userId', 'dummy-id__0123456789'),
     nanoId: text('nanoId', 'dummy-nano-id'),
   },
-  on: {
-    click: e => console.info(e.detail),
-  },
 })
 
 export const お気に入り_１文字 = () => ({
@@ -28,9 +25,6 @@ export const お気に入り_１文字 = () => ({
     type: select('type', BreadType, BreadType.FAVORITES),
     userId: text('userId', 'a'),
     nanoId: text('nanoId', 'dummy-nano-id'),
-  },
-  on: {
-    click: e => console.info(e.detail),
   },
 })
 
@@ -45,9 +39,6 @@ export const 自作_３０文字 = () => ({
     userId: text('userId', 'self_made'),
     nanoId: text('nanoId', 'dummy-nano-id'),
   },
-  on: {
-    click: e => console.info(e.detail),
-  },
 })
 
 export const キャッシュ = () => ({
@@ -57,8 +48,5 @@ export const キャッシュ = () => ({
     type: select('type', BreadType, BreadType.CACHE),
     userId: text('userId', 'downloaded'),
     nanoId: text('nanoId', 'dummy-nano-id'),
-  },
-  on: {
-    click: e => console.info(e.detail),
   },
 })

--- a/src/components/parts/Bread/Summary.svelte
+++ b/src/components/parts/Bread/Summary.svelte
@@ -1,19 +1,11 @@
 <script>
-  import { createEventDispatcher } from 'svelte'
+  import { link } from 'svelte-spa-router'
   import { getFrameBase64 } from '../../../utils/bread'
 
   export let title = ''
   export let userId = 0
   export let nanoId = ''
   export let type = 0
-
-  const dispatch = createEventDispatcher()
-
-  function onClick() {
-    dispatch('click', {
-      nanoId,
-    })
-  }
 </script>
 
 <style>
@@ -25,7 +17,8 @@
     width: 200px;
     height: 200px;
     padding: 40px 20px 20px;
-    cursor: pointer;
+    text-decoration: none;
+    color: initial;
   }
 
   .title {
@@ -41,10 +34,11 @@
   }
 </style>
 
-<div
+<a
   class="bread"
-  on:click={onClick}
+  href="/breads/detail/{nanoId}"
+  use:link
   style="background-image: url({getFrameBase64(type)})">
   <div class="title">{title}</div>
   <div class="author">@{userId}</div>
-</div>
+</a>

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -1,6 +1,0 @@
-import { push } from 'svelte-spa-router'
-
-export function moveBreadDetail(e) {
-  const nanoId = e.detail.nanoId
-  push(`/breads/detail/${nanoId}`)
-}


### PR DESCRIPTION
パン一覧画面で、パン詳細へのリンクをaタグに変更し、右クリックやホイールクリックから新しいタブで開けるようにする