### PR TITLE
キャッシュ状態をページ間をまたいで保存する対応

### DIFF
--- a/src/components/containers/BreadGroup/Cache.svelte
+++ b/src/components/containers/BreadGroup/Cache.svelte
@@ -1,53 +1,28 @@
 <script>
-  import { onMount } from 'svelte'
-  import { SIZE } from '../../../../const/pager'
   import BreadType from '../../../const/bread-type'
-  import { getBreads } from '../../../utils/idb'
+  import {
+    items,
+    showReadMore,
+    fetch,
+    fetchReadMore,
+  } from '../../../states/breads-summary/cache'
   import Group from '../../parts/Bread/Group'
 
   let isReading = false
-  let offsetFromLast = 0
-  let items = []
-  let nextBreads = []
-  let showReadMore = true
 
-  async function fetchBreads() {
-    let breads = []
-
-    if (nextBreads.length > 0) {
-      breads = nextBreads
-      nextBreads = []
-    } else {
-      breads = await getBreads(offsetFromLast)
-    }
-
-    if (breads.length === 0) {
-      return
-    }
-
-    items = [...items, ...breads]
-
-    offsetFromLast += SIZE
-
-    nextBreads = await getBreads(offsetFromLast)
-    showReadMore = nextBreads.length > 0
-  }
-
-  onMount(() => {
-    fetchBreads()
-  })
+  fetch()
 
   async function onReadMore() {
     isReading = true
-    await fetchBreads()
+    await fetchReadMore()
     isReading = false
   }
 </script>
 
 <Group
   type={BreadType.CACHE}
-  {items}
-  {showReadMore}
+  items={$items}
+  showReadMore={$showReadMore}
   description="パン詳細画面を開くと、IndexedDB
   を通してブラウザに保存されます。共有端末をご利用の方で、閲覧済みキャッシュを見られて困る方は、プライベートウィンドウでご利用ください。"
   {isReading}

--- a/src/states/breads-summary/cache.js
+++ b/src/states/breads-summary/cache.js
@@ -1,0 +1,55 @@
+import { get, writable, derived } from 'svelte/store'
+import { SIZE } from '../../../const/pager'
+import { getBreads } from '../../utils/idb'
+
+export const offsetFromLast = writable(0)
+export const items = writable([])
+export const nextBreads = writable([])
+export const showReadMore = derived(
+  nextBreads,
+  $nextBreads => $nextBreads.length > 0
+)
+export const fetched = writable(false)
+
+export function reset() {
+  items.set([])
+  nextBreads.set([])
+  fetched.set(false)
+}
+
+export async function fetch() {
+  if (get(fetched)) return
+
+  offsetFromLast.set(0)
+  const breads = await getBreads(get(offsetFromLast))
+
+  if (breads.length === 0) {
+    return
+  }
+
+  items.update($items => [...$items, ...breads])
+  offsetFromLast.update($offsetFromlast => $offsetFromlast + SIZE)
+  nextBreads.set(await getBreads(get(offsetFromLast)))
+  fetched.set(true)
+}
+
+export async function fetchReadMore() {
+  let breads = []
+  const $nextBreads = get(nextBreads)
+
+  if ($nextBreads.length > 0) {
+    breads = $nextBreads
+    nextBreads.set([])
+  } else {
+    breads = await getBreads(get(offsetFromLast))
+  }
+
+  if (breads.length === 0) {
+    return
+  }
+
+  items.update($items => [...$items, ...breads])
+  offsetFromLast.update($offsetFromlast => $offsetFromlast + SIZE)
+  nextBreads.set(await getBreads(get(offsetFromLast)))
+  fetched.set(true)
+}

--- a/src/states/breads-summary/favorites.js
+++ b/src/states/breads-summary/favorites.js
@@ -49,7 +49,7 @@ export async function fetch() {
 }
 
 export async function reload() {
-  fetched.set(false)
+  reset()
   await fetch()
 }
 

--- a/src/states/breads-summary/latest.js
+++ b/src/states/breads-summary/latest.js
@@ -38,7 +38,7 @@ export async function fetch() {
 }
 
 export async function reload() {
-  fetched.set(false)
+  reset()
   await fetch()
 }
 

--- a/src/states/breads-summary/self-made.js
+++ b/src/states/breads-summary/self-made.js
@@ -47,7 +47,7 @@ export async function fetch() {
 }
 
 export async function reload() {
-  fetched.set(false)
+  reset()
   await fetch()
 }
 


### PR DESCRIPTION
この対応により、キャッシュを６件以上開いている状態で、パンを表示してバックボタンで戻ったとき、キャッシュ済みパンが６件以上開かれたままとなる。