### PR TITLE
画像データのコピー＆ペースト禁止

### DIFF
--- a/src/components/parts/Bread/DragDrop.svelte
+++ b/src/components/parts/Bread/DragDrop.svelte
@@ -74,13 +74,7 @@
   accept="image/*"
   on:filedrop={onFileDrop}>
   <div class="message">
-    <p class="valid">
-      画像ファイルをドラッグ＆ドロップ
-      <br />
-      OR
-      <br />
-      画像データをコピー＆ペースト
-    </p>
+    <p class="valid">画像ファイルをドラッグ＆ドロップ</p>
     <p class="invalid">このファイルは指定できません</p>
   </div>
 </file-drop>

--- a/src/components/parts/Bread/DragDrop.svelte
+++ b/src/components/parts/Bread/DragDrop.svelte
@@ -24,7 +24,7 @@
     const image = await getImage(file)
 
     if (bread.image.validate(image) === Validation.SIZE_OVER) {
-      alert('ファイルサイズは2MBまでにしてください🙇🙇‍♀')
+      alert('ファイルサイズは1MBまでにしてください🙇🙇‍♀')
       return
     }
 
@@ -74,7 +74,13 @@
   accept="image/*"
   on:filedrop={onFileDrop}>
   <div class="message">
-    <p class="valid">画像ファイルをドラッグ＆ドロップ</p>
+    <p class="valid">
+      画像ファイルをドラッグ＆ドロップ
+      <br />
+      OR
+      <br />
+      画像データをコピー＆ペースト
+    </p>
     <p class="invalid">このファイルは指定できません</p>
   </div>
 </file-drop>

--- a/utils/validator/bread/image.js
+++ b/utils/validator/bread/image.js
@@ -1,5 +1,5 @@
 const Validation = require('../../../const/validation')
-exports.MAX_IMAGE_SIZE = 1024 * 1024 * 3 // 3MB
+exports.MAX_IMAGE_SIZE = 1024 * 1024 * 1 // 1MB
 
 exports.validate = value => {
   if (value.length === 0) {


### PR DESCRIPTION
大きい画像データをコピペしてサーバーに送信すると、サーバーエラーになる問題に対応。画像サイズが大きいと起こるように見えるため、一旦これで対応する。