### PR TITLE
回答作成時のOK・キャンセルにショートカットキーを割り当て

### DIFF
--- a/src/components/parts/Bread/Answer.svelte
+++ b/src/components/parts/Bread/Answer.svelte
@@ -27,7 +27,7 @@
   $: readingErrMsg = bread.reading.getErrMsg(reading)
   $: existsReading = !!reading
   $: disabledOk = !name || answserErrMsg || readingErrMsg
-  $: arrowAimUp = coord.top < 0.5
+  $: arrowAimUp = coord.top < 0.7
 
   const BALLOON_WIDTH = '30px'
   const dispatch = createEventDispatcher()
@@ -75,6 +75,27 @@
       ${rightStyle}
       ${isLeft ? leftStyle : ''}
     `
+  }
+
+  function onWindowKeyDown(event) {
+    if (event.key === 'Escape') {
+      onCancel()
+      return
+    }
+
+    if (event.ctrlKey && event.key === 'Enter' && !disabledOk) {
+      if (isEdit) {
+        onUpdate()
+      } else {
+        onCreate()
+      }
+
+      return
+    }
+
+    if (isEdit && event.key === 'Delete') {
+      onDelete()
+    }
   }
 </script>
 
@@ -165,6 +186,8 @@
   }
 </style>
 
+<svelte:window on:keydown={onWindowKeyDown} />
+
 <div class="wrapper" style={getWrapperStyle()}>
   <div
     class="answer"
@@ -213,17 +236,33 @@
     </div>
 
     <div class="buttons">
-      <Button passive text="キャンセル" disabled={false} on:click={onCancel} />
+      <Button
+        passive
+        text="キャンセル"
+        subText="( Escape )"
+        disabled={false}
+        on:click={onCancel} />
 
       {#if isEdit}
-        <Button negative text="削除" disabled={false} on:click={onDelete} />
+        <Button
+          negative
+          text="削除"
+          subText="( Delete )"
+          disabled={false}
+          on:click={onDelete} />
         <Button
           positive
           text="更新"
+          subText="(Ctrl + Enter)"
           disabled={disabledOk}
           on:click={onUpdate} />
       {:else}
-        <Button active text="作成" disabled={disabledOk} on:click={onCreate} />
+        <Button
+          active
+          text="作成"
+          subText="( Ctrl + Enter )"
+          disabled={disabledOk}
+          on:click={onCreate} />
       {/if}
     </div>
   </div>

--- a/src/components/parts/Bread/Answer.svelte
+++ b/src/components/parts/Bread/Answer.svelte
@@ -239,7 +239,7 @@
       <Button
         passive
         text="キャンセル"
-        subText="( Escape )"
+        subText="(Escape)"
         disabled={false}
         on:click={onCancel} />
 
@@ -247,7 +247,7 @@
         <Button
           negative
           text="削除"
-          subText="( Delete )"
+          subText="(Delete)"
           disabled={false}
           on:click={onDelete} />
         <Button
@@ -260,7 +260,7 @@
         <Button
           active
           text="作成"
-          subText="( Ctrl + Enter )"
+          subText="(Ctrl + Enter)"
           disabled={disabledOk}
           on:click={onCreate} />
       {/if}

--- a/src/components/parts/Bread/Image.svelte
+++ b/src/components/parts/Bread/Image.svelte
@@ -254,12 +254,6 @@
     answerNewIndex = answerIndex = i
   }
 
-  function onWindowKeyDown(e) {
-    if (e.keyCode === 27) {
-      init()
-    }
-  }
-
   function getAnswerCoord() {
     const { top, left, width, height } = currentRectangle
 
@@ -335,8 +329,6 @@
     max-height: 100%;
   }
 </style>
-
-<svelte:window on:keydown={onWindowKeyDown} />
 
 <div
   class="wrapper"

--- a/src/components/parts/Form/Button.stories.js
+++ b/src/components/parts/Form/Button.stories.js
@@ -50,7 +50,7 @@ export const Passive = () => ({
   Component: Button,
   props: {
     text: text('text', 'キャンセル'),
-    subText: text('subText', '(ESC)'),
+    subText: text('subText', '(Escape)'),
     passive: true,
     disabled: boolean('disabled', false),
   },
@@ -63,7 +63,7 @@ export const Negative = () => ({
   Component: Button,
   props: {
     text: text('text', '削除'),
-    subText: text('subText', ''),
+    subText: text('subText', '(Delete)'),
     negative: true,
     disabled: boolean('disabled', false),
   },
@@ -76,7 +76,7 @@ export const Positive = () => ({
   Component: Button,
   props: {
     text: text('text', 'OK'),
-    subText: text('subText', ''),
+    subText: text('subText', '(Ctrl + Enter)'),
     positive: true,
     disabled: boolean('disabled', false),
   },

--- a/src/components/parts/Form/Button.stories.js
+++ b/src/components/parts/Form/Button.stories.js
@@ -11,6 +11,7 @@ export const Hot = () => ({
   Component: Button,
   props: {
     text: text('text', 'ログイン'),
+    subText: text('subText', ''),
     hot: true,
     disabled: boolean('disabled', false),
   },
@@ -23,6 +24,7 @@ export const Calm = () => ({
   Component: Button,
   props: {
     text: text('text', 'ログアウト'),
+    subText: text('subText', ''),
     calm: true,
     disabled: boolean('disabled', false),
   },
@@ -35,6 +37,7 @@ export const Active = () => ({
   Component: Button,
   props: {
     text: text('text', 'パンを焼く'),
+    subText: text('subText', ''),
     active: true,
     disabled: boolean('disabled', false),
   },
@@ -47,6 +50,7 @@ export const Passive = () => ({
   Component: Button,
   props: {
     text: text('text', 'キャンセル'),
+    subText: text('subText', '(ESC)'),
     passive: true,
     disabled: boolean('disabled', false),
   },
@@ -59,6 +63,7 @@ export const Negative = () => ({
   Component: Button,
   props: {
     text: text('text', '削除'),
+    subText: text('subText', ''),
     negative: true,
     disabled: boolean('disabled', false),
   },
@@ -71,6 +76,7 @@ export const Positive = () => ({
   Component: Button,
   props: {
     text: text('text', 'OK'),
+    subText: text('subText', ''),
     positive: true,
     disabled: boolean('disabled', false),
   },

--- a/src/components/parts/Form/Button.svelte
+++ b/src/components/parts/Form/Button.svelte
@@ -1,5 +1,6 @@
 <script>
   export let text = ''
+  export let subText = ''
   export let hot = false
   export let calm = false
   export let active = false
@@ -21,6 +22,10 @@
     text-align: center;
     border-radius: 4px;
     appearance: none;
+  }
+
+  .sub {
+    font-size: 80%;
   }
 
   .button:hover {
@@ -79,4 +84,7 @@
   class:negative
   on:click>
   {text}
+  {#if subText}
+    <span class="sub">{subText}</span>
+  {/if}
 </button>


### PR DESCRIPTION
* 回答作成・更新時は Ctrl + Enter で可能に
* キャンセルは Esc で可能に（もともと可能で、表記した）
* 削除は Del で可能に
* 合わせて回答を上に表示する判定部分を修正（下に表示されるとスクロールできるが、上にはスクロール出来なかったため）
